### PR TITLE
Change dependency from Router to RouterInterface

### DIFF
--- a/src/Console/ProfilerToolbarRenderer.php
+++ b/src/Console/ProfilerToolbarRenderer.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 use function trim;
 use Twig\Environment;
 use function usort;
@@ -30,7 +30,7 @@ use function usort;
 class ProfilerToolbarRenderer
 {
     /**
-     * @var Router
+     * @var RouterInterface
      */
     private $router;
 
@@ -69,7 +69,7 @@ class ProfilerToolbarRenderer
      * @param array<string> $hiddenPanels
      */
     public function __construct(
-        Router $router,
+        RouterInterface $router,
         Profiler $profiler,
         Environment $twig,
         array $templates,


### PR DESCRIPTION
This patch fixes an error when the symfony router is overridden:
```
Symfony\Component\Debug\Exception\FatalThrowableError^ {#8
  -originalClassName: "TypeError"
  #message: "Sourceability\ConsoleToolbarBundle\Console\ProfilerToolbarRenderer::__construct(): Argument #1 ($router) must be of type Symfony\Component\Routing\Router, EmmaCare\Shared\Service\Router given, called in /tmp/symfony/chat/local/Container1eAVnW7/getSourceability_ConsoleToolbar_Console_ProfilerToolbarRendererService.php on line 9"
  #code: 0
  #file: "./vendor/sourceability/console-toolbar-bundle/src/Console/ProfilerToolbarRenderer.php"
  #line: 71
  #severity: E_RECOVERABLE_ERROR
  trace: {
    ./vendor/sourceability/console-toolbar-bundle/src/Console/ProfilerToolbarRenderer.php:71 { …}
    /tmp/symfony/chat/local/Container1eAVnW7/getSourceability_ConsoleToolbar_Console_ProfilerToolbarRendererService.php:9 {
      require^
      › 
      › return $this->services['sourceability.console_toolbar.console.profiler_toolbar_renderer'] = new \Sourceability\ConsoleToolbarBundle\Console\ProfilerToolbarRenderer(($this->services['router'] ?? $this->getRouterService()), ($this->services['profiler'] ?? $this->getProfilerService()), ($this->services['twig'] ?? $this->getTwigService()), $this->parameters['data_collector.templates'], [0 => 'config', 1 => 'form', 2 => 'validator', 3 => 'logger'], 30);
      › 
      arguments: {
        $router: EmmaCare\Shared\Service\Router {#8581 …}
        $profiler: Symfony\Component\HttpKernel\Profiler\Profiler {#9514 …}
        $twig: Twig\Environment {#10540 …}
        $templates: array:23 [ …23]
        $hiddenPanels: array:4 [ …4]
        $maxColumnWidth: 30
      }
    }
    /tmp/symfony/chat/local/Container1eAVnW7/srcApp_KernelLocalDebugContainer.php:192 { …}
    /tmp/symfony/chat/local/Container1eAVnW7/getSourceability_ConsoleToolbar_EventListener_ConsoleToolbarListenerService.php:9 { …}
    /tmp/symfony/chat/local/Container1eAVnW7/srcApp_KernelLocalDebugContainer.php:192 { …}
    /tmp/symfony/chat/local/Container1eAVnW7/srcApp_KernelLocalDebugContainer.php:709 { …}
    ./vendor/symfony/event-dispatcher/EventDispatcher.php:279 { …}
    ./vendor/symfony/event-dispatcher/EventDispatcher.php:90 { …}
    ./vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:334 { …}
    ./vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:162 { …}
    ./vendor/symfony/console/Application.php:1042 { …}
    ./vendor/symfony/framework-bundle/Console/Application.php:97 { …}
    ./vendor/symfony/console/Application.php:273 { …}
    ./vendor/symfony/framework-bundle/Console/Application.php:83 { …}
    ./vendor/symfony/console/Application.php:149 { …}
    ./bin/console:39 { …}
  }
}

```