### PR TITLE
Add full_stack variable

### DIFF
--- a/src/Console/ProfilerToolbarRenderer.php
+++ b/src/Console/ProfilerToolbarRenderer.php
@@ -195,6 +195,7 @@ class ProfilerToolbarRenderer
             // 1 = original toolbar, 2 = Symfony 2.8+ toolbar
             'csp_script_nonce' => null,
             'csp_style_nonce' => null,
+            'full_stack' => class_exists('Symfony\Bundle\FullStack'),
         ]);
 
         $crawler = new Crawler();


### PR DESCRIPTION
Symfony 5.4 crashing when running behat tests because the `full_stack` variable doesn't exist and get passed to `toolbar.html.twig`

See the [addition of the variable](https://github.com/symfony/web-profiler-bundle/commit/f6b6063007dcf564656ccf1c3981b02bd1c698d1) in the `web-profile-bundle`

The `if` call  in the template fails
```twig
{% if full_stack %}
```

Note, the IDE didn't want to recognize `FullStack::class` as an existing class, so I went with `Symfony\Bundle\FullStack`  (which is the class's full path) instead. 

Testing locally, this fix allowed my behat tests to run again
