### PR TITLE
Fix Symfony 6 bug in Configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('base_url')
                             ->defaultValue('http://localhost')
                             ->info('This is not used, please set the router request context instead.')
-                            ->setDeprecated()
+                            ->setDeprecated('sourceability/console-toolbar-bundle', '0.1.3')
                         ->end()
                     ->end()
                 ->end()


### PR DESCRIPTION
Symfony 6 requires the package and version parameters to be set when
calling `setDeprecated`.  This updates the file to name both this bundle
and the earliest version where the deprecation was introduced.